### PR TITLE
qt-xyplotter-demo: Update to fix build issues with fido release

### DIFF
--- a/recipes-qt/packagegroups/packagegroup-qte-toolchain-target.bb
+++ b/recipes-qt/packagegroups/packagegroup-qte-toolchain-target.bb
@@ -10,7 +10,7 @@ RDEPENDS_${PN} += " \
 	libmcc \
 	libmcc-dev \
 	libmcc-staticdev \
-	kernel-module-mcc \
-	kernel-module-mcc-dev \
-	kernel-headers \
+	kernel-module-mcc-toradex \
+	kernel-module-mcc-toradex-dev \
+	kernel-devsrc \
 "


### PR DESCRIPTION
- Update kernel-headers package to kernel-devsrc.
- Update the mcc modules package to avoid multiple
  providers for mcc modules package buring build.
